### PR TITLE
middleware, next-auth api route handler

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,15 @@
+import NextAuth, { type NextAuthOptions } from "next-auth";
+import GithubProvider from "next-auth/providers/github";
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GithubProvider({
+      clientId: process.env.GITHUB_ID || "",
+      clientSecret: process.env.GITHUB_SECRET || "",
+    }),
+  ],
+  
+};
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+export function middleware(request: Request) {
+  console.log("This is Middleware");
+  console.log(request.method);
+  console.log(request.url);
+
+  const origin = request.headers.get("origin");
+  console.log(origin);
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/api/:path*"],
+};


### PR DESCRIPTION
Basic middleware for api routes (only to console.log for now)
Basic next-auth for next 13.2.4 route handler, to GitHub provider